### PR TITLE
Implement user table migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,11 @@ down:
 	docker compose -f docker-compose.yml -f docker-compose.prod.yml down
 
 tree:
-	zsh scripts/gen_tree.sh
+        zsh scripts/gen_tree.sh
+
+migrate:
+        uv run alembic upgrade head
+
+revision:
+        uv run alembic revision --autogenerate -m "$(shell git rev-parse --abbrev-ref HEAD)_$(shell date +%Y%m%d_%H%M%S)"
+

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+APP_CONTAINER=wea-app-dev
+
 dev-up:
 	docker compose -f docker-compose.yml -f docker-compose.dev.yml up
 
@@ -11,11 +13,13 @@ down:
 	docker compose -f docker-compose.yml -f docker-compose.prod.yml down
 
 tree:
-        zsh scripts/gen_tree.sh
+	zsh scripts/gen_tree.sh
 
 migrate:
-        uv run alembic upgrade head
+	docker compose exec $(APP_CONTAINER) uv run alembic upgrade head
 
 revision:
-        uv run alembic revision --autogenerate -m "$(shell git rev-parse --abbrev-ref HEAD)_$(shell date +%Y%m%d_%H%M%S)"
+	docker compose exec $(APP_CONTAINER) uv run alembic revision --autogenerate -m "$(shell git rev-parse --abbrev-ref HEAD)_$(shell date +%Y%m%d_%H%M%S)"
 
+rollback:
+	docker compose exec $(APP_CONTAINER) uv run alembic downgrade -1

--- a/app/user/models.py
+++ b/app/user/models.py
@@ -1,6 +1,6 @@
 from datetime import UTC, datetime
 
-from sqlalchemy import Column, DateTime, Integer, String
+from sqlalchemy import Boolean, Column, DateTime, Integer, String
 
 from app.core.database import Base
 
@@ -12,12 +12,14 @@ class User(Base):
 
     __tablename__ = "user"
 
-    id = Column(Integer, primary_key=True, index=True)
+    id = Column(Integer, primary_key=True, autoincrement=True)
     line_user_id = Column(String, unique=True, index=True, nullable=False)
     display_name = Column(String, nullable=True)
-    quota = Column(Integer, default=5)  # default daily quota
-    quota_used = Column(Integer, default=0)
-    created_at = Column(DateTime, default=lambda: datetime.now(UTC))
+    is_active = Column(Boolean, default=True, nullable=False)
+    created_at = Column(DateTime, default=lambda: datetime.now(UTC), nullable=False)
     updated_at = Column(
-        DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC)
+        DateTime,
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+        nullable=False,
     )

--- a/app/user/schemas.py
+++ b/app/user/schemas.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from pydantic import BaseModel
 
 
@@ -22,8 +24,9 @@ class UserRead(BaseModel):
     id: int
     line_user_id: str
     display_name: str | None = None
-    quota: int = 5
-    quota_used: int = 0
+    is_active: bool = True
+    created_at: datetime
+    updated_at: datetime
 
     model_config = {"from_attributes": True}
 

--- a/migrations/versions/b05ddf47e04e_create_user_table.py
+++ b/migrations/versions/b05ddf47e04e_create_user_table.py
@@ -1,0 +1,54 @@
+"""create_user_table
+
+Revision ID: b05ddf47e04e
+Revises:
+Create Date: 2025-06-20 09:21:12.700261
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "b05ddf47e04e"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create user table."""
+    op.create_table(
+        "user",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("line_user_id", sa.String(), nullable=False, unique=True),
+        sa.Column("display_name", sa.String(), nullable=True),
+        sa.Column(
+            "is_active",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index(op.f("ix_user_line_user_id"), "user", ["line_user_id"], unique=True)
+
+
+def downgrade() -> None:
+    """Drop user table."""
+    op.drop_index(op.f("ix_user_line_user_id"), table_name="user")
+    op.drop_table("user")


### PR DESCRIPTION
## Summary
- add User table creation migration
- revise SQLAlchemy model fields
- expand `UserRead` schema to expose database metadata
- add Makefile shortcuts for Alembic
- improve `revision` command to auto-title migrations

## Testing
- `uv run ruff check .`
- `uv run ruff format .`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_685527b95e8c8325a4b1ea44ef9a8a48