### PR TITLE
[codex] Add scheduled pip-audit ignore check

### DIFF
--- a/.github/workflows/check-pip-audit-ignores.yml
+++ b/.github/workflows/check-pip-audit-ignores.yml
@@ -1,0 +1,22 @@
+name: Check pip-audit ignores
+
+on:
+  schedule:
+    - cron: "0 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check-pip-audit-ignores:
+    name: Check pip-audit ignores
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6  # Official GitHub action, keep version tag
+
+      - name: Check ignored advisories
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python3 scripts/check_pip_audit_ignores.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: uv run bandit -c bandit.yaml -r app
 
       - name: Dependency vulnerability scan (pip-audit)
-        run: uv run pip-audit --progress-spinner=off --ignore-vuln=GHSA-xqrq-4mgf-ff32 --ignore-vuln=GHSA-4xh5-x5gv-qwph
+        run: uv run pip-audit --progress-spinner=off --ignore-vuln=GHSA-58qw-9mgm-455v
 
       - name: Run unit tests with coverage
         # Run tests and generate coverage.xml with pytest-cov

--- a/Makefile
+++ b/Makefile
@@ -138,8 +138,8 @@ security-bandit:
 security-audit:
 	@echo "🔍 執行 pip-audit 依賴弱點掃描..."
 	@mkdir -p security-reports
-	@uv run pip-audit --format=json --output=security-reports/pip-audit-report.json --ignore-vuln=GHSA-xqrq-4mgf-ff32 --ignore-vuln=GHSA-4xh5-x5gv-qwph
-	@uv run pip-audit --ignore-vuln=GHSA-xqrq-4mgf-ff32 --ignore-vuln=GHSA-4xh5-x5gv-qwph
+	@uv run pip-audit --format=json --output=security-reports/pip-audit-report.json --ignore-vuln=GHSA-58qw-9mgm-455v
+	@uv run pip-audit --ignore-vuln=GHSA-58qw-9mgm-455v
 
 security-all:
 	@echo "🛡️ 執行完整安全掃描..."

--- a/docs/security-scan/implementation-highlights.md
+++ b/docs/security-scan/implementation-highlights.md
@@ -38,8 +38,7 @@ WeaMind 是一個智慧天氣 LINE Bot，本次實作為專案加入了完整的
 ```yaml
 # 已評估並合理忽略的低風險弱點
 ignored_vulnerabilities:
-  - GHSA-xqrq-4mgf-ff32  # future package - 間接依賴，風險可控
-  - GHSA-4xh5-x5gv-qwph  # pip tool - 容器化環境，攻擊面有限
+  - GHSA-58qw-9mgm-455v  # pip - upstream 尚無修正版，定期檢查退場條件
 ```
 
 ### 3. 自動化流程整合

--- a/docs/security-scan/makefile-commands-guide.md
+++ b/docs/security-scan/makefile-commands-guide.md
@@ -65,13 +65,12 @@ make security-audit
 5. 在控制台顯示掃描摘要
 
 **忽略的弱點**：
-- `GHSA-xqrq-4mgf-ff32`：future package 的低風險問題
-- `GHSA-4xh5-x5gv-qwph`：pip tool 的低風險問題
+- `GHSA-58qw-9mgm-455v`：pip 目前尚無修正版的中風險問題
 
 **輸出範例**：
 ```
 🔍 執行 pip-audit 依賴弱點掃描...
-No known vulnerabilities found, 2 ignored
+No known vulnerabilities found, 1 ignored
 ```
 
 **報告檔案**：
@@ -249,7 +248,7 @@ uv run pre-commit run --hook-stage pre-push bandit
   run: uv run bandit -c bandit.yaml -r app
 
 - name: Dependency vulnerability scan (pip-audit)
-  run: uv run pip-audit --progress-spinner=off --ignore-vuln=GHSA-xqrq-4mgf-ff32 --ignore-vuln=GHSA-4xh5-x5gv-qwph
+  run: uv run pip-audit --progress-spinner=off --ignore-vuln=GHSA-58qw-9mgm-455v
 ```
 
 ### 本機 pre-commit hook

--- a/docs/security-scan/security-scan.md
+++ b/docs/security-scan/security-scan.md
@@ -17,23 +17,14 @@ WeaMind 使用多層安全檢查來確保程式碼和依賴的安全性。
 
 基於風險評估，以下弱點已被標記為忽略：
 
-### GHSA-xqrq-4mgf-ff32 (future v1.0.0)
-- **風險等級**：低
-- **描述**：Python-Future 模組會自動導入同目錄下的 test.py 檔案
+### GHSA-58qw-9mgm-455v (pip <= 26.0.1)
+- **風險等級**：中
+- **描述**：pip 對同時可被判讀為 tar 與 ZIP 的封包存在解析衝突，可能導致安裝內容與檔名暗示不一致。
 - **忽略原因**：
-  - 這是間接依賴，由 line-bot-sdk 引入
-  - 我們的部署環境不包含可執行的 test.py 檔案
-  - 攻擊者需要先取得檔案寫入權限才能利用此漏洞
-  - 風險在控制範圍內
-
-### GHSA-4xh5-x5gv-qwph (pip v25.2)
-- **風險等級**：低
-- **描述**：pip 在解壓惡意 sdist 時可能發生路徑穿越攻擊
-- **忽略原因**：
-  - 這是 uv 工具內建的 pip 版本
-  - 我們使用 uv.lock 鎖定依賴，不直接從不信任的來源安裝套件
-  - 生產環境使用 Docker 容器隔離
-  - 攻擊需要安裝特製的惡意套件，不適用於我們的使用場景
+  - GitHub Advisory 目前尚未提供 `first_patched_version`
+  - 專案已鎖定到目前可用的新版 pip
+  - `uv.lock` 鎖定依賴來源，CI 不從任意未知來源安裝套件
+  - 已新增定期檢查，當 advisory withdrawn 或出現修正版時會提醒移除 ignore
 
 ## 安全掃描流程
 
@@ -85,7 +76,7 @@ make security-audit
 3. 在此文件中記錄忽略原因
 
 ### 定期檢查
-建議每季度重新評估已忽略的弱點，確保風險仍在可接受範圍內。
+GitHub Actions 每週執行 `Check pip-audit ignores`，檢查已忽略的 GHSA 是否已 withdrawn 或出現 `first_patched_version`。若已可處理，workflow 會失敗並提示升級依賴後移除 ignore。
 
 ## 最佳實踐
 

--- a/docs/security-scan/virtualenv-security-fix-and-dependabot-analysis.md
+++ b/docs/security-scan/virtualenv-security-fix-and-dependabot-analysis.md
@@ -59,10 +59,9 @@ Audited 98 packages in 8ms
 ### 5. 本地測試
 ```bash
 ❯ uv run pip-audit --progress-spinner=off \
-  --ignore-vuln=GHSA-xqrq-4mgf-ff32 \
-  --ignore-vuln=GHSA-4xh5-x5gv-qwph
+  --ignore-vuln=GHSA-58qw-9mgm-455v
 
-No known vulnerabilities found
+No known vulnerabilities found, 1 ignored
 ```
 
 ### 6. 提交修復
@@ -240,8 +239,7 @@ update-deps:
   run: |
     uv run pip-audit \
       --progress-spinner=off \
-      --ignore-vuln=GHSA-xqrq-4mgf-ff32 \
-      --ignore-vuln=GHSA-4xh5-x5gv-qwph
+      --ignore-vuln=GHSA-58qw-9mgm-455v
 ```
 
 ### 4. 定期維護週期

--- a/scripts/check_pip_audit_ignores.py
+++ b/scripts/check_pip_audit_ignores.py
@@ -1,0 +1,167 @@
+"""Check whether pip-audit vulnerability ignores can be removed."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+IGNORE_PATTERN = re.compile(r"--ignore-vuln=(GHSA-[a-z0-9]+-[a-z0-9]+-[a-z0-9]+)")
+SKIP_DIRS = {
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".venv",
+    "__pycache__",
+    "htmlcov",
+    "security-reports",
+}
+
+
+@dataclass(frozen=True)
+class IgnoreHit:
+    """A pip-audit ignore found in a repository file."""
+
+    advisory_id: str
+    path: Path
+    line_number: int
+
+
+@dataclass(frozen=True)
+class AdvisoryStatus:
+    """The current GitHub Advisory state for an ignored GHSA."""
+
+    advisory_id: str
+    html_url: str
+    summary: str
+    withdrawn_at: str | None
+    patched_versions: tuple[str, ...]
+
+    @property
+    def is_actionable(self) -> bool:
+        """Return whether this ignored advisory may be removed or upgraded away."""
+        return self.withdrawn_at is not None or bool(self.patched_versions)
+
+
+def should_skip(path: Path) -> bool:
+    """Return whether a path should be excluded from repository scanning."""
+    return any(part in SKIP_DIRS for part in path.parts)
+
+
+def find_ignore_hits(root: Path) -> list[IgnoreHit]:
+    """Find all pip-audit GHSA ignores in text files under the repository root."""
+    hits: list[IgnoreHit] = []
+    for path in root.rglob("*"):
+        if not path.is_file() or should_skip(path):
+            continue
+
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except UnicodeDecodeError:
+            continue
+
+        for line_number, line in enumerate(lines, start=1):
+            hits.extend(
+                IgnoreHit(
+                    advisory_id=match.group(1),
+                    path=path.relative_to(root),
+                    line_number=line_number,
+                )
+                for match in IGNORE_PATTERN.finditer(line)
+            )
+    return hits
+
+
+def fetch_advisory(advisory_id: str) -> dict[str, Any]:
+    """Fetch one GitHub Advisory document from the public advisory API."""
+    request = urllib.request.Request(
+        f"https://api.github.com/advisories/{advisory_id}",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
+
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        message = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"Failed to fetch {advisory_id}: HTTP {exc.code}: {message}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"Failed to fetch {advisory_id}: {exc.reason}") from exc
+
+
+def parse_advisory(advisory_id: str, payload: dict[str, Any]) -> AdvisoryStatus:
+    """Convert a GitHub Advisory API payload into the status this check needs."""
+    patched_versions: set[str] = set()
+    for vulnerability in payload.get("vulnerabilities", []):
+        patched_version = vulnerability.get("first_patched_version")
+        if patched_version:
+            patched_versions.add(str(patched_version))
+
+    return AdvisoryStatus(
+        advisory_id=advisory_id,
+        html_url=str(payload.get("html_url", "")),
+        summary=str(payload.get("summary", "")),
+        withdrawn_at=payload.get("withdrawn_at"),
+        patched_versions=tuple(sorted(patched_versions)),
+    )
+
+
+def print_report(hits: list[IgnoreHit], statuses: dict[str, AdvisoryStatus]) -> int:
+    """Print a human-readable report and return the intended process exit code."""
+    if not hits:
+        print("No pip-audit GHSA ignores found.")
+        return 0
+
+    print("Found pip-audit GHSA ignores:")
+    for hit in hits:
+        print(f"- {hit.advisory_id} at {hit.path}:{hit.line_number}")
+
+    actionable = [status for status in statuses.values() if status.is_actionable]
+    if not actionable:
+        print("\nNo ignored advisories are currently actionable.")
+        for status in statuses.values():
+            print(f"- {status.advisory_id}: still ignored; no patched version and not withdrawn.")
+        return 0
+
+    print("\nAction required: at least one ignored advisory may be removable.")
+    for status in actionable:
+        print(f"- {status.advisory_id}: {status.summary}")
+        if status.withdrawn_at:
+            print(f"  withdrawn_at: {status.withdrawn_at}")
+        if status.patched_versions:
+            versions = ", ".join(status.patched_versions)
+            print(f"  first_patched_version: {versions}")
+        if status.html_url:
+            print(f"  advisory: {status.html_url}")
+    print("\nTry updating the affected dependency and remove the ignore if pip-audit passes.")
+    return 1
+
+
+def main() -> int:
+    """Run the stale pip-audit ignore check."""
+    root = Path.cwd()
+    hits = find_ignore_hits(root)
+    advisory_ids = sorted({hit.advisory_id for hit in hits})
+    statuses = {
+        advisory_id: parse_advisory(advisory_id, fetch_advisory(advisory_id))
+        for advisory_id in advisory_ids
+    }
+    return print_report(hits, statuses)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -1150,11 +1150,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.0"
+version = "26.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/44/c2/65686a7783a7c27a329706207147e82f23c41221ee9ae33128fc331670a0/pip-26.0.tar.gz", hash = "sha256:3ce220a0a17915972fbf1ab451baae1521c4539e778b28127efa79b974aff0fa", size = 1812654, upload-time = "2026-01-31T01:40:54.361Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/83/0d7d4e9efe3344b8e2fe25d93be44f64b65364d3c8d7bc6dc90198d5422e/pip-26.0.1.tar.gz", hash = "sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8", size = 1812747, upload-time = "2026-02-05T02:20:18.702Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/00/5ac7aa77688ec4d34148b423d34dc0c9bc4febe0d872a9a1ad9860b2f6f1/pip-26.0-py3-none-any.whl", hash = "sha256:98436feffb9e31bc9339cf369fd55d3331b1580b6a6f1173bacacddcf9c34754", size = 1787564, upload-time = "2026-01-31T01:40:52.252Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl", hash = "sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b", size = 1787723, upload-time = "2026-02-05T02:20:16.416Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Update the pip lock entry from 26.0 to 26.0.1 and keep only the currently needed pip-audit ignore.
- Add a weekly/manual GitHub Actions workflow that checks whether ignored GHSA advisories are withdrawn or have a patched version.
- Add a repository script for the advisory check and sync the security-scan docs with the current ignore list.

## Root cause
CI failed because pip-audit began reporting GHSA-58qw-9mgm-455v for pip 26.0. The GitHub Advisory currently has no first_patched_version, so the ignore is still required, but older ignores were stale and removable.

## Validation
- python3 scripts/check_pip_audit_ignores.py
- uv run pip-audit --progress-spinner=off --ignore-vuln=GHSA-58qw-9mgm-455v
- uv run ruff check .
- uv run ruff format . --check
- git diff --cached --check
- pre-commit hooks during git commit