### PR TITLE
Harden GHCR publish checkout

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -24,8 +24,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          # 使用觸發 CI 的那個 commit SHA，確保版本一致
-          ref: ${{ github.event.workflow_run.head_sha }}
+          # Checkout trusted branch, then verify it still points to the CI-passed commit.
+          ref: main
+
+      - name: Verify published commit
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          CHECKED_OUT_SHA="$(git rev-parse HEAD)"
+          if [ "$CHECKED_OUT_SHA" != "$HEAD_SHA" ]; then
+            echo "main moved after CI completed; skip publishing stale commit."
+            echo "checked_out_sha=$CHECKED_OUT_SHA"
+            echo "workflow_run_head_sha=$HEAD_SHA"
+            exit 1
+          fi
 
       # 第二步：設定 Docker Buildx（支援多平台 build 與快取）
       - name: Set up Docker Buildx


### PR DESCRIPTION
## Summary
- checkout the trusted main branch in the privileged GHCR publish workflow
- verify the checked-out commit still matches the CI-passed workflow_run head SHA before publishing
- keep image tags based on the CI-passed SHA

## Security validation
- Removes the CodeQL actions/untrusted-checkout pattern by avoiding checkout of an event-controlled SHA in a workflow_run context.
- Preserves the invariant that the published image must match the commit that passed CI; if main moves before the publish job checks out code, the job exits before login/build/push.

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish-ghcr.yml"); puts "yaml ok"'
- rg -n 'ref: main|Verify published commit|workflow_run.head_sha' .github/workflows/publish-ghcr.yml
- pre-commit hooks via git commit