### PR TITLE
[codex] Remove GHCR SHA image tag

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -51,20 +51,8 @@ jobs:
           username: ${{ github.actor }}             # 觸發 workflow 的使用者名稱（自動）
           password: ${{ secrets.GITHUB_TOKEN }}     # GitHub 自動提供的 token（不需手動建立）
 
-      # 第四步：計算 tag 名稱
-      - name: Compute tags
-        id: meta  # 設定 id，讓後續步驟可以用 steps.meta.outputs.xxx 取值
-        env:
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-        run: |
-          # 取觸發 CI 的 commit SHA 前 7 碼（例如：ab788e3）
-          SHORT_SHA="${HEAD_SHA::7}"
-          # 輸出到 GITHUB_OUTPUT，供下一步使用
-          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
-          echo "full_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
-
-      # 第五步：Build 並 Push image 到 GHCR
-      # 同時推送兩個 tag：latest（永遠指向最新版）和 sha-xxx（可追溯版本）
+      # 第四步：Build 並 Push image 到 GHCR
+      # 只推送 latest；語意化版本 tags 由 publish-release.yml 負責
       - name: Build and push
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
@@ -74,7 +62,6 @@ jobs:
           platforms: linux/amd64,linux/arm64  # 支援 x86_64 和 ARM64（Apple Silicon）
           tags: |
             ghcr.io/${{ github.repository_owner }}/weamind:latest
-            ghcr.io/${{ github.repository_owner }}/weamind:sha-${{ steps.meta.outputs.short_sha }}
           # 使用 GitHub Actions 內建快取，加速 build
           cache-from: type=gha    # 從 GitHub Actions cache 讀取
           cache-to: type=gha,mode=max  # 寫入 cache（mode=max 快取所有 layers）


### PR DESCRIPTION
## Summary
- Stop publishing `sha-*` tags from the main-branch GHCR publish workflow.
- Keep `latest` publishing on successful main CI runs.
- Leave semantic version image tags to the release workflow.

## Why
Frequent documentation/article updates create many low-value SHA image tags, which makes the semantic version tags harder to see in GHCR.

## Validation
- `git diff --check -- .github/workflows/publish-ghcr.yml`
- pre-commit hooks during commit, including YAML validation and secret detection