### PR TITLE
Skip Codecov upload for Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,8 @@ jobs:
           uv run pytest --cov=app --cov-report=xml --cov-report=term-missing
 
       - name: Upload coverage to Codecov
-        # Upload coverage report to Codecov
+        # Dependabot pull_request runs cannot access CODECOV_TOKEN on protected branches.
+        if: ${{ github.event_name != 'pull_request' || github.actor != 'dependabot[bot]' }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
 
         with:


### PR DESCRIPTION
## Summary
- Skip the Codecov upload step on Dependabot pull_request runs, where CODECOV_TOKEN is unavailable on protected branches.
- Keep coverage generation, quality checks, and Codecov fail-on-error behavior for main pushes and non-Dependabot PRs.

## Verification
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci.yml parses"'
- pre-commit hooks from git commit: YAML, whitespace, secrets, and file checks passed

## Maintenance context
- Unblocks Dependabot GitHub Actions PRs #111, #112, and #113, whose failed CI logs show Codecov upload failing with: Token required because branch is protected.