### PR TITLE
Update Redis to security release 8.2.8

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -29,7 +29,7 @@ services:
     container_name: wea-redis-prod
     restart: always
     ports:
-      - "6379:6379"
+      - "10.0.0.2:6379:6379"
     volumes:
       - wea-redis-data-prod:/data
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     networks:
       - wea-net
   redis:
-    image: redis:8.2.1-bookworm
+    image: redis:8.2.8-bookworm
     networks:
       - wea-net
 


### PR DESCRIPTION
## Summary

- update the Redis server from 8.2.1 to the patched 8.2.8 release
- bind the production Redis port to the bastion private IP only

## Validation

- Docker Compose production configuration validation
- Redis 8.2.8 container startup and PING smoke test
- DEBUG=false uv run pytest tests/core/test_processing_lock.py (13 passed)