### PR TITLE
Require CHANGELOG approval before release

### DIFF
--- a/.github/prompts/changelog.prompt.md
+++ b/.github/prompts/changelog.prompt.md
@@ -1,5 +1,5 @@
 ---
-description: "CHANGELOG maintenance and release workflow"
+description: "Approval-gated CHANGELOG maintenance and release workflow"
 ---
 
 # WeaMind CHANGELOG Maintenance Guide
@@ -12,9 +12,30 @@ Use this prompt when the user asks to update the CHANGELOG or release a version.
 
 1. Use the Makefile commands first.
 2. Follow the standard release flow in order.
-3. Keep the CHANGELOG user-facing, concise, and focused on product value.
-4. Exclude non-functional changes such as spelling rules, documentation cleanup, dependency bumps, CI changes, refactors, and formatting-only edits.
-5. For major or minor releases, write a fuller entry. For patch releases, keep the entry short.
+3. Draft the CHANGELOG entry without editing any files, then wait for explicit user approval.
+4. Do not update files, commit, tag, push, or release until the user approves the exact CHANGELOG content.
+5. Keep the CHANGELOG user-facing, concise, and focused on product value.
+6. Exclude non-functional changes such as spelling rules, documentation cleanup, routine dependency bumps, CI changes, refactors, and formatting-only edits.
+7. For major or minor releases, write a fuller entry. For patch releases, keep the entry short.
+
+## Required Approval Gate
+
+After preparing the commit data:
+
+1. Draft the complete CHANGELOG entry, including version, date, sections, and bullets.
+2. Show the exact proposed Markdown to the user.
+3. Report which source commits were included and which meaningful candidates were excluded.
+4. Stop and wait for explicit approval such as `核可` or `approved`.
+
+Before approval, do not:
+
+- edit `CHANGELOG.md`
+- edit `pyproject.toml` or `uv.lock`
+- run `make changelog-release`
+- create commits or tags
+- push changes or trigger a release
+
+Silence, a version request, or an ambiguous response is not approval. If the user requests revisions, update the draft, show the full revised Markdown, and wait for approval again.
 
 ## Release Flow
 
@@ -24,20 +45,28 @@ Use this prompt when the user asks to update the CHANGELOG or release a version.
    - Review the summary of changes.
 2. Prepare the release input with `make changelog-prepare VERSION=x.y.z`.
    - Collect commit data.
-   - Generate the Copilot Chat prompt text.
-   - Produce a formatted change list.
-3. Write the CHANGELOG entry in Copilot Chat using the prepared commits.
+   - Review the generated writing guidance.
+   - Identify the product-facing changes since the latest tag.
+3. Draft the CHANGELOG entry using the prepared commits.
    - Use Keep a Changelog format.
    - Write in Traditional Chinese.
    - Focus on user value and product impact.
    - Add only meaningful product changes.
-4. Release the version with `make changelog-release VERSION=x.y.z`.
+   - Do not edit any files yet.
+4. Present the exact draft and source-commit summary to the user, then stop.
+5. After explicit user approval, write the approved entry to `CHANGELOG.md` without changing its wording.
+6. Release the version with `make changelog-release VERSION=x.y.z`.
+   - Require a clean `main` branch except for the approved `CHANGELOG.md` change.
    - Update the version in `pyproject.toml`.
    - Run `uv lock` to refresh `uv.lock`.
-   - Commit `CHANGELOG.md`, `pyproject.toml`, and `uv.lock`.
-   - Create the git tag.
-   - Push the changes.
-   - Trigger GitHub Actions to create the release.
+   - Commit `CHANGELOG.md` separately.
+   - Commit `pyproject.toml` and `uv.lock` as the version release.
+   - Create and push the annotated version tag.
+7. Verify the automated release results.
+   - Confirm the main CI and CodeQL runs succeed.
+   - Confirm GitHub Release creation succeeds.
+   - Confirm the versioned multi-platform GHCR image is published.
+   - Confirm the automated `weamind-infra` version-update PR is created.
 
 ## CHANGELOG Writing Rules
 
@@ -49,9 +78,11 @@ Use this heading format:
 
 ### Section Order
 
-1. Added
-2. Fixed
-3. Changed
+Include only sections that contain meaningful entries, in this order:
+
+1. 新增
+2. 修正
+3. 改進
 
 ### Writing Style
 
@@ -75,7 +106,7 @@ Exclude commits that are not user-facing, such as:
 
 - cSpell dictionary updates
 - documentation micro-edits
-- dependency version bumps
+- routine dependency version bumps without a user-facing or security impact
 - CI changes
 - refactors
 - formatting-only changes
@@ -91,17 +122,20 @@ Exclude commits that are not user-facing, such as:
 
 ### Git Reference Commands
 
-- `git log --oneline v0.1.0..HEAD`
-- `git log --oneline --merges v0.1.0..HEAD`
-- `git diff --stat v0.1.0..HEAD`
+- `git log --oneline <latest-tag>..HEAD`
+- `git log --oneline --merges <latest-tag>..HEAD`
+- `git diff --stat <latest-tag>..HEAD`
 
 ## Checklist
 
 - Run `make changelog-status`.
 - Run `make changelog-prepare VERSION=x.y.z`.
 - Draft the CHANGELOG entry from the prepared commits.
+- Show the exact draft and source commits to the user.
+- Receive explicit user approval.
+- Update `CHANGELOG.md` with the approved content.
 - Run `make changelog-release VERSION=x.y.z`.
-- Confirm the GitHub Actions release succeeded.
+- Confirm CI, CodeQL, GitHub Release, GHCR publishing, and infra PR creation succeeded.
 
 ## Output Requirements
 
@@ -110,4 +144,6 @@ When finishing, report:
 1. the version being released
 2. the source commits used
 3. the files updated
-4. the verification result
+4. the release commits and tag
+5. the GitHub Release and infra PR links
+6. the verification result


### PR DESCRIPTION
## Summary

- align the CHANGELOG prompt with the current release automation
- require explicit user approval of the exact CHANGELOG draft before any file update or release action
- document current GitHub Release, GHCR, and infra PR verification steps

## Validation

- uv run pre-commit run --files .github/prompts/changelog.prompt.md
- git diff --check