### PR TITLE
Resolve CodeQL maintenance alerts

### DIFF
--- a/app/line/messaging.py
+++ b/app/line/messaging.py
@@ -163,7 +163,7 @@ class ReplyMessenger(Protocol):
 
     def reply(self, reply_token: str | None, recipe: ReplyRecipe) -> SendResult:
         """Send one recipe using the supplied reply token."""
-        ...
+        raise NotImplementedError
 
 
 @dataclass(frozen=True, slots=True)

--- a/scripts/performance_test.py
+++ b/scripts/performance_test.py
@@ -240,7 +240,6 @@ def test_taiwan_bounds_performance() -> None:
         avg_batch_time = statistics.mean(times)
         time_per_check = avg_batch_time / num_runs * 1000  # microseconds
 
-        inside = 21.9 <= lat <= 26.5 and 118.0 <= lon <= 122.0
         status = "✅ Inside" if inside else "❌ Outside"
         print(f"({lat:7.4f}, {lon:8.4f}) {status} - {time_per_check:.3f}μs per check")
 


### PR DESCRIPTION
## Summary

- make the reply protocol default behavior explicit
- reuse the benchmarked Taiwan bounds result instead of redefining it
- resolve CodeQL alerts #53 and #54 without suppressions

## Root cause

A protocol stub used an ineffectual ellipsis expression, and the performance benchmark recalculated a value immediately before using it even though the timed loop had already produced the same result.

## Impact

No production behavior changes. The benchmark performs the same boundary checks and the protocol continues to require concrete adapters to implement reply.

## Verification

- `uv run pytest` (298 passed)
- `uv run ruff check .`
- `uv run pyright .`
- `uv run bandit -c bandit.yaml -r app`
- `uv run python scripts/performance_test.py`
- `git diff --check`